### PR TITLE
Integrate with 'Open URL in container' extension

### DIFF
--- a/src/tab-util.js
+++ b/src/tab-util.js
@@ -27,6 +27,12 @@ export async function rightmostTab(windowId) {
   return tabs[tabs.length - 1];
 }
 
+// Returns the tabs.Tab of the leading to the rightmost tab in the given window
+export async function secondRightmostTab(windowId) {
+  const tabs = await browser.tabs.query({ windowId });
+  return tabs[tabs.length - 2];
+}
+
 // Returns the tab following the given one, or undefined if there is none
 export async function nextTab(tab) {
   const tabs = await browser.tabs.query({


### PR DESCRIPTION
Adds support to create temp containers externally, and have them managed by this extension.

This allows to integrate with 'Open URL in container' extension, to click on a URL and have it open in a new temp container, and let this extension track that container just as if it was created using the extension. In order to trigger this, a new container name, as passed from 'Open URL in container', must equal to '%TEMP%'.

Fixes #15 